### PR TITLE
add data folder mount and andor device resource

### DIFF
--- a/services/bl99p-ea-ioc-05/values.yaml
+++ b/services/bl99p-ea-ioc-05/values.yaml
@@ -1,6 +1,20 @@
 # yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/3.4.4/ioc-instance.schema.json#/$defs/service
 ioc-instance:
-  image: REPLACE_WITH_IMAGE_URI
+  image: gcr.io/diamond-privreg/controls/work/iocs/ioc-adandor-linux-runtime:2024.10.1
+
+  dataVolume:
+    pvc: false
+    hostPath: /dls/p99/data
+
+  resources:
+    limits:
+      cpu: 2
+      memory: 512Mi
+      diamond.ac.uk/andorUSB: 1
+    requests:
+      cpu: 500m
+      memory: 128Mi
+      diamond.ac.uk/andorUSB: 1
 
   # NOTE: the following are suggestions to help with debugging IOCs
   # 1. replace the runtime container with the developer version


### PR DESCRIPTION
Changes to the values.yaml helm overrides file for bl99p-ea-ioc-05
- add a mount of the shared data folder at /dls/p99/data
- add a resource request for the andor camera itself